### PR TITLE
feat: shadow dom support

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -9,6 +9,7 @@ type StoryFn = () => HTMLElement;
 
 CaptureAnnouncements({
     onCapture: (text, level) => AnnouncementEvents.emit({ text, level }),
+    includeShadowDom: true,
 });
 
 addons.getChannel().addListener(STORY_CHANGED, () => {

--- a/.storybook/stories/ShadowRoot.stories.ts
+++ b/.storybook/stories/ShadowRoot.stories.ts
@@ -1,7 +1,7 @@
 import { createButtonCycle } from '../utils';
 
 export default {
-    title: 'Unsupported/ShadowRoot',
+    title: 'DOM API Support/ShadowRoot',
 };
 
 export function liveRegionInsideShadowDOM() {

--- a/.storybook/stories/ShadowRoot.stories.ts
+++ b/.storybook/stories/ShadowRoot.stories.ts
@@ -88,3 +88,30 @@ export function liveRegionDeeplyInShadowDOM() {
         }
     );
 }
+
+export function liveRegionWrappingElementAndShadowDOM() {
+    let shadowRoot: ShadowRoot;
+
+    return createButtonCycle(
+        parent => {
+            const region = document.createElement('div');
+            region.setAttribute('aria-live', 'polite');
+            parent.appendChild(region);
+
+            const host = document.createElement('div');
+            region.appendChild(host);
+
+            shadowRoot = host.attachShadow({ mode: 'open' });
+        },
+        () => {
+            const hello = document.createElement('div');
+            hello.textContent = 'Hello';
+
+            const world = document.createElement('div');
+            world.textContent = 'world';
+
+            shadowRoot.appendChild(hello);
+            shadowRoot.host.appendChild(world);
+        }
+    );
+}

--- a/README.md
+++ b/README.md
@@ -42,12 +42,11 @@ Pass `onCapture` callback to handle announcements.
 |   announcement    | `string` | Text content of the announcement |
 | politenessSetting | `string` | `polite\|assertive`              |
 
+<!-- prettier-ignore -->
 ```ts
 CaptureAnnouncements({
     onCapture: (announcement, politenessSetting) => {
-        console.log(
-            `"${announcement}" was announced with politeness setting "${politenessSetting}"`
-        );
+        console.log(`"${announcement}" was announced with politeness setting "${politenessSetting}"`);
     },
 });
 ```
@@ -55,6 +54,17 @@ CaptureAnnouncements({
 ```
 "Loading" was announced with politeness setting "polite"
 "Failed to load user details" was announced with politeness setting "assertive"
+```
+
+### includeShadowDom
+
+Pass an optional boolean `includeShadowDom` option to include tracking of live regions in Shadow DOM.
+Default value is `false`.
+
+```ts
+CaptureAnnouncements({
+    includeShadowDom: true,
+});
 ```
 
 ### cleanup
@@ -156,6 +166,23 @@ PASS ✅  | "Loading" is announced
 Render#1 | <div role="status" aria-hidden="true">Loading</div>
 Render#2 | <div role="status" aria-hidden="false">Loading</div>
 FAIL ❌  | "Loading" is not announced
+```
+
+With option `{ includeShadowDom: true }`:
+
+<!-- prettier-ignore -->
+```html
+Render#1 | <div role="status">
+         |     #shadow-root
+         |     <div></div>
+         | </div>
+         |
+Render#2 | <div role="status">
+         |     #shadow-root
+         |     <div>Loading</div>
+         | </div>
+         |
+PASS ✅  | "Loading" is announced
 ```
 
 ## Support

--- a/src/capture-announcements.ts
+++ b/src/capture-announcements.ts
@@ -12,6 +12,7 @@ import {
 } from './utils';
 import { interceptMethod, interceptSetter, Restore } from './interceptors';
 import { isElement } from './dom-node-safe-guards';
+import { configure } from './config';
 
 interface Options {
     /** Callback invoked when announcement is captured */
@@ -19,12 +20,17 @@ interface Options {
         textContent: string,
         politenessSetting: Exclude<PolitenessSetting, 'off'>
     ) => void;
+
+    /** Indicates whether live regions inside `ShadowRoot`s should be tracked */
+    includeShadowDom?: boolean;
 }
 
 // Map of live regions to previous textContent
 const liveRegions = new Map<Node, string | null>();
 
 export default function CaptureAnnouncements(options: Options): Restore {
+    configure({ includeShadowDom: options.includeShadowDom || false });
+
     const onCapture: Options['onCapture'] = (
         textContent,
         politenessSetting

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,25 @@
+interface Config {
+    /** Indicates whether live regions inside `ShadowRoot`s should be tracked */
+    includeShadowDom?: boolean;
+}
+
+let config: Config = {
+    includeShadowDom: false,
+};
+
+/**
+ * Configure global options
+ */
+export function configure(newConfig: Config | Partial<Config>): void {
+    config = {
+        ...config,
+        ...newConfig,
+    };
+}
+
+/**
+ * Get global options
+ */
+export function getConfig(): Config {
+    return config;
+}

--- a/src/dom-node-safe-guards.ts
+++ b/src/dom-node-safe-guards.ts
@@ -9,3 +9,7 @@ export function isElement(node: Node | null): node is Element {
 export function isShadowRoot(node: Node | null): node is ShadowRoot {
     return node != null && node instanceof ShadowRoot;
 }
+
+export function isDocument(node: Node | null): node is Document {
+    return node != null && node.nodeType === Node.DOCUMENT_NODE;
+}

--- a/src/dom-node-safe-guards.ts
+++ b/src/dom-node-safe-guards.ts
@@ -5,3 +5,7 @@
 export function isElement(node: Node | null): node is Element {
     return node != null && node.nodeType === Node.ELEMENT_NODE;
 }
+
+export function isShadowRoot(node: Node | null): node is ShadowRoot {
+    return node != null && node instanceof ShadowRoot;
+}

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -1,5 +1,5 @@
 import { getConfig } from './config';
-import { isElement, isShadowRoot } from './dom-node-safe-guards';
+import { isDocument, isElement, isShadowRoot } from './dom-node-safe-guards';
 
 /**
  * `Element.closest` which traverses tree up when `ShadowRoot` is encountered
@@ -47,4 +47,86 @@ export function getChildNodes(node: Node): Node['childNodes'] {
     }
 
     return node.childNodes;
+}
+
+/**
+ * `querySelectorAll` which includes all contents of all `ShadowRoot`'s.
+ * Note that return type is directly `Element[]` instead of `NodeListOf`.
+ */
+export function querySelectorAll(
+    context: Document | Element,
+    ...args: Parameters<typeof context['querySelectorAll']>
+): Element[] {
+    if (!getConfig().includeShadowDom) {
+        return Array.from(context.querySelectorAll(...args));
+    }
+
+    const roots = [context, ...findShadowRoots([context])];
+
+    return roots.reduce<Element[]>(
+        (all, root) => [...all, ...root.querySelectorAll(...args)],
+        []
+    );
+}
+
+/**
+ * Finds `ShadowRoot`'s and their nested `ShadowRoot`'s
+ * - This is highly inspired by Cypress: https://github.com/cypress-io/cypress/blob/develop/packages/driver/src/dom/elements/shadow.ts
+ */
+function findShadowRoots(
+    nodes: Node[],
+    shadowRoots: ShadowRoot[] = []
+): ShadowRoot[] {
+    if (nodes.length === 0) return shadowRoots;
+
+    // Find new nested shadow roots
+    const rootsFromThisLevel = nodes.reduce<ShadowRoot[]>(
+        (all, node) => [...all, ...findShadowRootsOfNode(node)],
+        []
+    );
+
+    // Check whether newly found shadow roots have nested shadow roots
+    return findShadowRoots(rootsFromThisLevel, [
+        ...shadowRoots,
+        ...rootsFromThisLevel,
+    ]);
+}
+
+/**
+ * Finds all `ShadowRoot`'s of given node. Does not traverse nested `ShadowRoot`'s.
+ */
+function findShadowRootsOfNode(root: Node): ShadowRoot[] {
+    const doc = root.getRootNode({ composed: true });
+    const shadowRoots: ShadowRoot[] = [];
+
+    if (!isDocument(doc)) return shadowRoots;
+
+    if (isElement(root) && root.shadowRoot) {
+        shadowRoots.push(root.shadowRoot);
+    }
+
+    const treeWalker = doc.createTreeWalker(
+        root,
+        NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_DOCUMENT_FRAGMENT,
+        { acceptNode: acceptNodesWithShadowRoot }
+    );
+
+    function collectRoots(roots: ShadowRoot[]): ShadowRoot[] {
+        const nextNode = treeWalker.nextNode();
+
+        if (!isElement(nextNode)) return roots;
+        if (!nextNode.shadowRoot) return roots;
+
+        return collectRoots([...roots, nextNode.shadowRoot]);
+    }
+
+    return collectRoots(shadowRoots);
+}
+
+function acceptNodesWithShadowRoot(node: Node): number {
+    if (isElement(node) && node.shadowRoot) {
+        return NodeFilter.FILTER_ACCEPT;
+    }
+
+    return NodeFilter.FILTER_SKIP;
 }

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -1,0 +1,24 @@
+import { getConfig } from './config';
+import { isShadowRoot } from './dom-node-safe-guards';
+
+/**
+ * `Element.closest` which traverses tree up when `ShadowRoot` is encountered
+ */
+export function closest(
+    element: Element,
+    ...args: Parameters<Element['closest']>
+): ReturnType<Element['closest']> {
+    const result = element.closest(...args);
+
+    if (result || !getConfig().includeShadowDom) {
+        return result;
+    }
+
+    const rootNode = element.getRootNode();
+
+    if (isShadowRoot(rootNode)) {
+        return closest(rootNode.host, ...args);
+    }
+
+    return null;
+}

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -22,3 +22,18 @@ export function closest(
 
     return null;
 }
+
+/**
+ * `Node.parentNode` as method which traverses tree up when `ShadowRoot` is encountered
+ */
+export function getParentNode(node: Node): Node['parentNode'] {
+    if (node.parentNode || !getConfig().includeShadowDom) {
+        return node.parentNode;
+    }
+
+    if (isShadowRoot(node)) {
+        return node.host;
+    }
+
+    return null;
+}

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -1,5 +1,5 @@
 import { getConfig } from './config';
-import { isShadowRoot } from './dom-node-safe-guards';
+import { isElement, isShadowRoot } from './dom-node-safe-guards';
 
 /**
  * `Element.closest` which traverses tree up when `ShadowRoot` is encountered
@@ -36,4 +36,15 @@ export function getParentNode(node: Node): Node['parentNode'] {
     }
 
     return null;
+}
+
+/**
+ * `Node.childNodes` as method which traverses tree down when `ShadowRoot` is encountered
+ */
+export function getChildNodes(node: Node): Node['childNodes'] {
+    if (getConfig().includeShadowDom && isElement(node) && node.shadowRoot) {
+        return getChildNodes(node.shadowRoot);
+    }
+
+    return node.childNodes;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -85,7 +85,7 @@ export function isHidden(node: Node): boolean {
         return true;
     }
 
-    return element.closest(HIDDEN_QUERY) != null;
+    return queries.closest(element, HIDDEN_QUERY) != null;
 }
 
 export function getClosestLiveRegion(element: Element | null): Element | null {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,8 +41,10 @@ export function getClosestElement(node: Node): Element | null {
         return node;
     }
 
-    if (node.parentNode) {
-        return getClosestElement(node.parentNode);
+    const parentNode = queries.getParentNode(node);
+
+    if (parentNode) {
+        return getClosestElement(parentNode);
     }
 
     return null;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import { isElement } from './dom-node-safe-guards';
+import * as queries from './queries';
 
 export type PolitenessSetting = 'polite' | 'assertive' | 'off';
 
@@ -57,7 +58,9 @@ export function isLiveRegionAttribute(
 }
 
 export function isInDOM(node: Node): boolean {
-    return isElement(node) && node.closest('html') != null;
+    const element = getClosestElement(node);
+
+    return element != null && queries.closest(element, 'html') != null;
 }
 
 // TODO: Support `hidden` and CSS attributes:

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -147,14 +147,15 @@ export function getTextContent(node: Node | null): string | null {
         return node.textContent ? trimWhiteSpace(node.textContent) : null;
     }
 
-    if (!node.hasChildNodes()) return null;
+    const childNodes = queries.getChildNodes(node);
+    if (childNodes.length === 0) return null;
 
-    return trimWhiteSpace(
-        Array.from(node.childNodes)
-            .map(getTextContent)
-            .filter(Boolean)
-            .join(' ')
-    );
+    const textContent = Array.from(childNodes)
+        .map(getTextContent)
+        .filter(Boolean)
+        .join(' ');
+
+    return trimWhiteSpace(textContent);
 }
 
 function filterUnique<T>(item: T, index: number, array: T[]): boolean {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -22,7 +22,7 @@ const LIVE_REGION_QUERY = [
 const HIDDEN_QUERY = '[aria-hidden="true"]';
 
 export function getAllLiveRegions(context: Document | Element): Element[] {
-    const liveRegions = Array.from(context.querySelectorAll(LIVE_REGION_QUERY));
+    const liveRegions = queries.querySelectorAll(context, LIVE_REGION_QUERY);
 
     // Check whether given `context` is also a live region
     if (

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -89,7 +89,7 @@ export function isHidden(node: Node): boolean {
 }
 
 export function getClosestLiveRegion(element: Element | null): Element | null {
-    return element ? element.closest(LIVE_REGION_QUERY) : null;
+    return element ? queries.closest(element, LIVE_REGION_QUERY) : null;
 }
 
 function isPolitenessSetting(

--- a/test/capture-announcements.test.ts
+++ b/test/capture-announcements.test.ts
@@ -1,5 +1,6 @@
 import CaptureAnnouncements from '../src';
 import { __PrivateUnstableAPI } from '../src/capture-announcements';
+import { getConfig } from '../src/config';
 import {
     appendToRoot,
     POLITE_CASES,
@@ -611,5 +612,32 @@ describe('element tracking', () => {
 
         expect(liveRegions.size).toBe(1);
         expect(liveRegions.has(element)).toBe(true);
+    });
+});
+
+describe('config', () => {
+    let cleanup: undefined | ReturnType<typeof CaptureAnnouncements>;
+    const onCapture = jest.fn();
+
+    afterEach(() => {
+        cleanup?.();
+    });
+
+    test('resolves includeShadowDom when not configured', () => {
+        cleanup = CaptureAnnouncements({ onCapture });
+
+        expect(getConfig().includeShadowDom).toBe(false);
+    });
+
+    test('resolves includeShadowDom when configured true', () => {
+        cleanup = CaptureAnnouncements({ onCapture, includeShadowDom: true });
+
+        expect(getConfig().includeShadowDom).toBe(true);
+    });
+
+    test('resolves includeShadowDom when configured false', () => {
+        cleanup = CaptureAnnouncements({ onCapture, includeShadowDom: false });
+
+        expect(getConfig().includeShadowDom).toBe(false);
     });
 });

--- a/test/capture-announcements.test.ts
+++ b/test/capture-announcements.test.ts
@@ -1,6 +1,6 @@
 import CaptureAnnouncements from '../src';
 import { __PrivateUnstableAPI } from '../src/capture-announcements';
-import { getConfig } from '../src/config';
+import { configure, getConfig } from '../src/config';
 import {
     appendToRoot,
     POLITE_CASES,
@@ -612,6 +612,34 @@ describe('element tracking', () => {
 
         expect(liveRegions.size).toBe(1);
         expect(liveRegions.has(element)).toBe(true);
+    });
+
+    test('element in shadow dom is tracked', () => {
+        configure({ includeShadowDom: true });
+
+        const region = document.createElement('div');
+        region.setAttribute('aria-live', 'polite');
+
+        element.attachShadow({ mode: 'open' });
+        element.shadowRoot!.appendChild(region);
+        appendToRoot(element);
+
+        expect(liveRegions.size).toBe(1);
+        expect(liveRegions.has(region)).toBe(true);
+    });
+
+    test('does not track shadow doms when config.includeShadowDom is false', () => {
+        configure({ includeShadowDom: false });
+
+        const region = document.createElement('div');
+        region.setAttribute('aria-live', 'polite');
+
+        element.attachShadow({ mode: 'open' });
+        element.shadowRoot!.appendChild(region);
+        appendToRoot(element);
+
+        expect(liveRegions.size).toBe(0);
+        expect(liveRegions.has(region)).toBe(false);
     });
 });
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,6 +1,57 @@
 import { configure } from '../src/config';
-import { getTextContent, isInDOM } from '../src/utils';
+import { getClosestElement, getTextContent, isInDOM } from '../src/utils';
 import { appendToRoot } from './utils';
+
+describe('getClosestElement', () => {
+    test('returns itself when element', () => {
+        const element = document.createElement('div');
+
+        expect(getClosestElement(element)).toBe(element);
+    });
+
+    test('returns parent element of text node', () => {
+        const element = document.createElement('div');
+        const text = document.createTextNode('Hello world');
+        element.appendChild(text);
+
+        expect(getClosestElement(text)).toBe(element);
+    });
+
+    test('returns null when node has no parent', () => {
+        const text = document.createTextNode('Hello world');
+
+        expect(getClosestElement(text)).toBe(null);
+    });
+
+    test('returns null when node has parentless node as parent', () => {
+        const parentNode = { parentNode: null } as Node;
+        const text = { parentNode } as Node;
+
+        expect(getClosestElement(text)).toBe(null);
+    });
+
+    test('returns parent of element inside shadow root', () => {
+        configure({ includeShadowDom: true });
+
+        const text = document.createTextNode('Hello world');
+        const root = document.createElement('div');
+
+        root.attachShadow({ mode: 'open' }).appendChild(text);
+
+        expect(getClosestElement(text)).toBe(root);
+    });
+
+    test('does not traverse shadow dom when config.includeShadowDom is false', () => {
+        configure({ includeShadowDom: false });
+
+        const text = document.createTextNode('Hello world');
+        const root = document.createElement('div');
+
+        root.attachShadow({ mode: 'open' }).appendChild(text);
+
+        expect(getClosestElement(text)).toBe(null);
+    });
+});
 
 describe('getTextContent', () => {
     let root: HTMLElement;

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,4 +1,6 @@
-import { getTextContent } from '../src/utils';
+import { configure } from '../src/config';
+import { getTextContent, isInDOM } from '../src/utils';
+import { appendToRoot } from './utils';
 
 describe('getTextContent', () => {
     let root: HTMLElement;
@@ -91,5 +93,123 @@ describe('getTextContent', () => {
         `);
 
         expect(getTextContent(document.getElementById('temp'))).toBe(null);
+    });
+});
+
+describe('isInDOM', () => {
+    test('mounted element is in DOM', () => {
+        const element = document.createElement('div');
+        appendToRoot(element);
+
+        expect(isInDOM(element)).toBe(true);
+    });
+
+    test('unmounted element is not in DOM', () => {
+        const element = document.createElement('div');
+
+        expect(isInDOM(element)).toBe(false);
+    });
+
+    test('document body is in DOM', () => {
+        expect(isInDOM(document.body)).toBe(true);
+    });
+
+    test('mounted text node is in DOM', () => {
+        const element = document.createElement('div');
+        const text = document.createTextNode('Hello world');
+        element.appendChild(text);
+        appendToRoot(element);
+
+        expect(isInDOM(text)).toBe(true);
+    });
+
+    test('unmounted text node is not in DOM', () => {
+        const text = document.createTextNode('Hello world');
+
+        expect(isInDOM(text)).toBe(false);
+    });
+
+    test('element inside mounted shadow root is in DOM', () => {
+        configure({ includeShadowDom: true });
+
+        const parent = document.createElement('div');
+        const shadowRoot = parent.attachShadow({ mode: 'open' });
+        appendToRoot(parent);
+
+        const element = document.createElement('div');
+        shadowRoot.appendChild(element);
+
+        expect(isInDOM(element)).toBe(true);
+    });
+
+    test('does not traverse shadow dom when config.includeShadowDom is false', () => {
+        configure({ includeShadowDom: false });
+
+        const parent = document.createElement('div');
+        const shadowRoot = parent.attachShadow({ mode: 'open' });
+        appendToRoot(parent);
+
+        const element = document.createElement('div');
+        shadowRoot.appendChild(element);
+
+        expect(isInDOM(element)).toBe(false);
+    });
+
+    test('element inside unmounted shadow root is not in DOM', () => {
+        configure({ includeShadowDom: true });
+
+        const parent = document.createElement('div');
+        const shadowRoot = parent.attachShadow({ mode: 'open' });
+
+        const element = document.createElement('div');
+        shadowRoot.appendChild(element);
+
+        expect(isInDOM(element)).toBe(false);
+    });
+
+    test('text node inside mounted shadow root is in DOM', () => {
+        configure({ includeShadowDom: true });
+
+        const parent = document.createElement('div');
+        const shadowRoot = parent.attachShadow({ mode: 'open' });
+        appendToRoot(parent);
+
+        const text = document.createTextNode('Hello world');
+        const element = document.createElement('div');
+        element.appendChild(text);
+        shadowRoot.appendChild(element);
+
+        expect(isInDOM(text)).toBe(true);
+    });
+
+    test('text node inside unmounted shadow root is not in DOM', () => {
+        configure({ includeShadowDom: true });
+
+        const parent = document.createElement('div');
+        const shadowRoot = parent.attachShadow({ mode: 'open' });
+
+        const text = document.createTextNode('Hello world');
+        const element = document.createElement('div');
+        element.appendChild(text);
+        shadowRoot.appendChild(element);
+
+        expect(isInDOM(text)).toBe(false);
+    });
+
+    test('element inside multiple nested mounted shadow roots is in DOM', () => {
+        configure({ includeShadowDom: true });
+
+        const firstParent = document.createElement('div');
+        firstParent.attachShadow({ mode: 'open' });
+        appendToRoot(firstParent);
+
+        const secondParent = document.createElement('div');
+        secondParent.attachShadow({ mode: 'open' });
+        firstParent.shadowRoot!.appendChild(secondParent);
+
+        const element = document.createElement('div');
+        secondParent.shadowRoot!.appendChild(element);
+
+        expect(isInDOM(element)).toBe(true);
     });
 });

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -3,6 +3,7 @@ import {
     getClosestElement,
     getClosestLiveRegion,
     getTextContent,
+    isHidden,
     isInDOM,
 } from '../src/utils';
 import { appendToRoot } from './utils';
@@ -203,6 +204,121 @@ describe('getTextContent', () => {
         `);
 
         expect(getTextContent(document.getElementById('temp'))).toBe(null);
+    });
+});
+
+describe('isHidden', () => {
+    test('node without parent is hidden', () => {
+        const text = document.createTextNode('Hello world');
+
+        expect(isHidden(text)).toBe(true);
+    });
+
+    test('element with aria-hidden="true" is hidden', () => {
+        const element = document.createElement('div');
+        element.setAttribute('aria-hidden', 'true');
+
+        expect(isHidden(element)).toBe(true);
+    });
+
+    test('element with aria-hidden="false" is visible', () => {
+        const element = document.createElement('div');
+        element.setAttribute('aria-hidden', 'false');
+
+        expect(isHidden(element)).toBe(false);
+    });
+
+    test('element with aria-live="off" is hidden', () => {
+        const element = document.createElement('div');
+        element.setAttribute('aria-live', 'off');
+
+        expect(isHidden(element)).toBe(true);
+    });
+
+    test('element with aria-live="polite" is visible', () => {
+        const element = document.createElement('div');
+        element.setAttribute('aria-live', 'polite');
+
+        expect(isHidden(element)).toBe(false);
+    });
+
+    test('element with aria-live="assertive" is visible', () => {
+        const element = document.createElement('div');
+        element.setAttribute('aria-live', 'assertive');
+
+        expect(isHidden(element)).toBe(false);
+    });
+
+    test('element with role="marquee" is hidden', () => {
+        const element = document.createElement('div');
+        element.setAttribute('role', 'marquee');
+
+        expect(isHidden(element)).toBe(true);
+    });
+
+    test('element with role="timer" is hidden', () => {
+        const element = document.createElement('div');
+        element.setAttribute('role', 'timer');
+
+        expect(isHidden(element)).toBe(true);
+    });
+
+    test('element with role="status" is visible', () => {
+        const element = document.createElement('div');
+        element.setAttribute('role', 'status');
+
+        expect(isHidden(element)).toBe(false);
+    });
+
+    test('element having parent with aria-hidden="true" is hidden', () => {
+        const element = document.createElement('div');
+        const parent = document.createElement('div');
+        parent.setAttribute('aria-hidden', 'true');
+        parent.appendChild(element);
+
+        expect(isHidden(element)).toBe(true);
+    });
+
+    test('element in shadow root having parent with aria-hidden="true" is hidden', () => {
+        configure({ includeShadowDom: true });
+
+        const element = document.createElement('div');
+        const parent = document.createElement('div');
+        const shadowRoot = parent.attachShadow({ mode: 'open' });
+
+        parent.setAttribute('aria-hidden', 'true');
+        shadowRoot.appendChild(element);
+
+        expect(isHidden(element)).toBe(true);
+    });
+
+    test('element deeply in shadow root having parent up in the tree with aria-hidden="true" is hidden', () => {
+        configure({ includeShadowDom: true });
+
+        const hiddenParent = document.createElement('div');
+        const parentWithShadowRoow = document.createElement('div');
+        hiddenParent.setAttribute('aria-hidden', 'true');
+        hiddenParent.appendChild(parentWithShadowRoow);
+
+        const element = document.createElement('div');
+        const shadowRoot = parentWithShadowRoow.attachShadow({ mode: 'open' });
+
+        shadowRoot.appendChild(element);
+
+        expect(isHidden(element)).toBe(true);
+    });
+
+    test('does not traverse shadow dom when config.includeShadowDom is false', () => {
+        configure({ includeShadowDom: false });
+
+        const element = document.createElement('div');
+        const parent = document.createElement('div');
+        const shadowRoot = parent.attachShadow({ mode: 'open' });
+
+        parent.setAttribute('aria-hidden', 'true');
+        shadowRoot.appendChild(element);
+
+        expect(isHidden(element)).toBe(false);
     });
 });
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -205,6 +205,62 @@ describe('getTextContent', () => {
 
         expect(getTextContent(document.getElementById('temp'))).toBe(null);
     });
+
+    test('returns text content from inside shadow dom', () => {
+        configure({ includeShadowDom: true });
+
+        html(`
+            <div>
+                <div id="host"></div>
+            </div>
+        `);
+
+        const host = document.getElementById('host')!;
+        const shadowRoot = host.attachShadow({ mode: 'open' });
+
+        const wrapper = document.createElement('div');
+        wrapper.appendChild(document.createTextNode('Hello world'));
+        shadowRoot.appendChild(wrapper);
+
+        expect(getTextContent(root)).toBe('Hello world');
+    });
+
+    test('returns text content from wrapped shadow dom', () => {
+        configure({ includeShadowDom: true });
+
+        html(`
+            <div>
+                <div id="host"></div>
+            </div>
+        `);
+
+        const shadowRoot = document
+            .getElementById('host')!
+            .attachShadow({ mode: 'open' });
+
+        shadowRoot.appendChild(document.createTextNode('Hello world'));
+
+        expect(getTextContent(root)).toBe('Hello world');
+    });
+
+    test('does not traverse shadow dom when config.includeShadowDom is false', () => {
+        configure({ includeShadowDom: false });
+
+        html(`
+            <div>
+                <div id="host"></div>
+            </div>
+        `);
+
+        const host = document.getElementById('host')!;
+        const shadowRoot = host.attachShadow({ mode: 'open' });
+
+        const wrapper = document.createElement('div');
+        wrapper.appendChild(document.createTextNode('Hello world'));
+        shadowRoot.appendChild(wrapper);
+
+        expect(getTextContent(root)).toBe(null);
+    });
 });
 
 describe('isHidden', () => {


### PR DESCRIPTION
- docs: mark `ShadowRoot` as supported
- feat(shadow-dom): `getAllLiveRegions` to traverse down elements with shadowRoot
- feat(shadow-dom): `getTextContent` to traverse down elements with shadowRoot
- feat(shadow-dom): `isHidden` to traverse up the shadow root host
- feat(shadow-dom): `getClosestLiveRegion` to traverse up elements with shadowRoot
- feat(shadow-dom): `getClosestElement` to traverse up the shadow root host
- feat(shadow-dom): `isInDOM` to traverse up the shadow root host
- feat(shadow-dom): add `includeShadowDom` option