### PR TITLE
docs: shadow-root examples

### DIFF
--- a/.storybook/pretty-dom-with-shadow-dom.ts
+++ b/.storybook/pretty-dom-with-shadow-dom.ts
@@ -1,0 +1,294 @@
+/*
+ * Copy of `@testing-library/dom`'s `DOMElementFilter.ts` with slight modifications
+ * to include `ShadowRoot`s contents in output of `prettyDOM` calls.
+ *
+ * https://github.com/testing-library/dom-testing-library/blob/main/src/DOMElementFilter.ts
+ */
+
+import { prettyDOM } from '@testing-library/dom';
+import type { Config, NewPlugin, Printer, Refs } from 'pretty-format';
+
+export default function prettyDOMWithShadowDOM(
+    ...args: Parameters<typeof prettyDOM>
+): ReturnType<typeof prettyDOM> {
+    const [dom, maxLength, options] = args;
+
+    const plugin: NewPlugin = {
+        test: (val: any) => val?.constructor?.name && testNode(val),
+        serialize,
+    };
+
+    return prettyDOM(dom, maxLength, {
+        ...options,
+        plugins: [plugin],
+        filterNode: () => true,
+    });
+}
+
+function escapeHTML(str: string): string {
+    return str.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+// Return empty string if keys is empty.
+function printProps(
+    keys: Array<string>,
+    props: Record<string, unknown>,
+    config: Config,
+    indentation: string,
+    depth: number,
+    refs: Refs,
+    printer: Printer
+): string {
+    const indentationNext = indentation + config.indent;
+    const colors = config.colors;
+    return keys
+        .map(key => {
+            const value = props[key];
+            let printed = printer(value, config, indentationNext, depth, refs);
+
+            if (typeof value !== 'string') {
+                if (printed.indexOf('\n') !== -1) {
+                    printed =
+                        config.spacingOuter +
+                        indentationNext +
+                        printed +
+                        config.spacingOuter +
+                        indentation;
+                }
+                printed = '{' + printed + '}';
+            }
+
+            return (
+                config.spacingInner +
+                indentation +
+                colors.prop.open +
+                key +
+                colors.prop.close +
+                '=' +
+                colors.value.open +
+                printed +
+                colors.value.close
+            );
+        })
+        .join('');
+}
+
+// https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType#node_type_constants
+const NodeTypeTextNode = 3;
+
+// Return empty string if children is empty.
+const printChildren = (
+    children: Array<unknown>,
+    config: Config,
+    indentation: string,
+    depth: number,
+    refs: Refs,
+    printer: Printer
+): string =>
+    children
+        .map(child => {
+            const printedChild =
+                typeof child === 'string'
+                    ? printText(child, config)
+                    : printer(child, config, indentation, depth, refs);
+
+            if (
+                printedChild === '' &&
+                typeof child === 'object' &&
+                child !== null &&
+                (child as Node).nodeType !== NodeTypeTextNode
+            ) {
+                // A plugin serialized this Node to '' meaning we should ignore it.
+                return '';
+            }
+            return config.spacingOuter + indentation + printedChild;
+        })
+        .join('');
+
+const printText = (text: string, config: Config): string => {
+    const contentColor = config.colors.content;
+    return contentColor.open + escapeHTML(text) + contentColor.close;
+};
+
+const printComment = (comment: string, config: Config): string => {
+    const commentColor = config.colors.comment;
+    return (
+        commentColor.open +
+        '<!--' +
+        escapeHTML(comment) +
+        '-->' +
+        commentColor.close
+    );
+};
+
+// Separate the functions to format props, children, and element,
+// so a plugin could override a particular function, if needed.
+// Too bad, so sad: the traditional (but unnecessary) space
+// in a self-closing tagColor requires a second test of printedProps.
+const printElement = (
+    type: string,
+    printedProps: string,
+    printedChildren: string,
+    hasShadowRoot: boolean,
+    config: Config,
+    indentation: string
+): string => {
+    const tagColor = config.colors.tag;
+    const shadowRootMarkup = hasShadowRoot
+        ? `${config.spacingOuter + indentation}  #shadow-root`
+        : '';
+
+    return (
+        tagColor.open +
+        '<' +
+        type +
+        (printedProps &&
+            tagColor.close +
+                printedProps +
+                config.spacingOuter +
+                indentation +
+                tagColor.open) +
+        (printedChildren
+            ? '>' +
+              shadowRootMarkup +
+              tagColor.close +
+              printedChildren +
+              config.spacingOuter +
+              indentation +
+              tagColor.open +
+              '</' +
+              type
+            : (printedProps && !config.min ? '' : ' ') + '/') +
+        '>' +
+        tagColor.close
+    );
+};
+
+const printElementAsLeaf = (type: string, config: Config): string => {
+    const tagColor = config.colors.tag;
+    return (
+        tagColor.open +
+        '<' +
+        type +
+        tagColor.close +
+        ' …' +
+        tagColor.open +
+        ' />' +
+        tagColor.close
+    );
+};
+
+const ELEMENT_NODE = 1;
+const TEXT_NODE = 3;
+const COMMENT_NODE = 8;
+const FRAGMENT_NODE = 11;
+
+const ELEMENT_REGEXP = /^((HTML|SVG)\w*)?Element$/;
+
+const testNode = (val: any) => {
+    const constructorName = val.constructor.name;
+    const { nodeType, tagName } = val;
+    const isCustomElement =
+        (typeof tagName === 'string' && tagName.includes('-')) ||
+        (typeof val.hasAttribute === 'function' && val.hasAttribute('is'));
+
+    return (
+        (nodeType === ELEMENT_NODE &&
+            (ELEMENT_REGEXP.test(constructorName) || isCustomElement)) ||
+        (nodeType === TEXT_NODE && constructorName === 'Text') ||
+        (nodeType === COMMENT_NODE && constructorName === 'Comment') ||
+        (nodeType === FRAGMENT_NODE && constructorName === 'DocumentFragment')
+    );
+};
+
+type HandledType = Element | Text | Comment | DocumentFragment;
+
+function nodeIsText(node: HandledType): node is Text {
+    return node.nodeType === TEXT_NODE;
+}
+
+function nodeIsComment(node: HandledType): node is Comment {
+    return node.nodeType === COMMENT_NODE;
+}
+
+function nodeIsFragment(node: HandledType): node is DocumentFragment {
+    return node.nodeType === FRAGMENT_NODE;
+}
+
+function serialize(
+    node: HandledType,
+    config: Config,
+    indentation: string,
+    depth: number,
+    refs: Refs,
+    printer: Printer
+): string {
+    if (nodeIsText(node)) {
+        return printText(node.data, config);
+    }
+
+    if (nodeIsComment(node)) {
+        return printComment(node.data, config);
+    }
+
+    const type = nodeIsFragment(node)
+        ? `DocumentFragment`
+        : node.tagName.toLowerCase();
+
+    if (++depth > config.maxDepth) {
+        return printElementAsLeaf(type, config);
+    }
+
+    const children = printChildren(
+        getChildren(node),
+        config,
+        indentation + config.indent,
+        depth,
+        refs,
+        printer
+    );
+
+    const hasShadowRoot = 'shadowRoot' in node && node.shadowRoot != null;
+
+    return printElement(
+        type,
+        printProps(
+            nodeIsFragment(node)
+                ? []
+                : Array.from(node.attributes)
+                      .map(attr => attr.name)
+                      .sort(),
+            nodeIsFragment(node)
+                ? {}
+                : Array.from(node.attributes).reduce<Record<string, string>>(
+                      (props, attribute) => {
+                          props[attribute.name] = attribute.value;
+                          return props;
+                      },
+                      {}
+                  ),
+            config,
+            indentation + config.indent,
+            depth,
+            refs,
+            printer
+        ),
+        children,
+        hasShadowRoot,
+        config,
+        indentation
+    );
+}
+
+function getChildren(node: Element | DocumentFragment): Node[] {
+    const shadowRoot = node instanceof Element && node.shadowRoot;
+
+    const nodes = [node, shadowRoot].filter(Boolean);
+
+    const children = nodes.reduce(
+        (all, current) => [...all, ...(current.childNodes || current.children)],
+        []
+    );
+
+    return children;
+}

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,6 +1,5 @@
-import { prettyDOM } from '@testing-library/dom';
-
 import CaptureAnnouncements from '../src';
+import prettyDOMWithShadowDOM from './pretty-dom-with-shadow-dom';
 import { AnnouncementEvents, SourceCodeUpdateEvents } from './utils';
 
 type StoryFn = () => HTMLElement;
@@ -24,7 +23,11 @@ export const decorators = [
         `.trim();
 
         function updateSourceCodeFrame() {
-            const code = compose(escapeHTML, formatSourceCode, prettyDOM)(html);
+            const code = compose(
+                escapeHTML,
+                formatSourceCode,
+                prettyDOMWithShadowDOM
+            )(html);
 
             sourceCodeFrame.querySelector(`#${sourceCodeId}`).innerHTML = code;
         }

--- a/.storybook/stories/ShadowRoot.stories.ts
+++ b/.storybook/stories/ShadowRoot.stories.ts
@@ -1,0 +1,51 @@
+import { createButtonCycle } from '../utils';
+
+export default {
+    title: 'Unsupported/ShadowRoot',
+};
+
+export function liveRegionInsideShadowDOM() {
+    let shadowRoot: ShadowRoot;
+    let element: HTMLElement;
+
+    return createButtonCycle(
+        parent => {
+            const host = document.createElement('div');
+            parent.appendChild(host);
+
+            shadowRoot = host.attachShadow({ mode: 'open' });
+        },
+        () => {
+            element = document.createElement('div');
+            element.setAttribute('aria-live', 'polite');
+
+            shadowRoot.appendChild(element);
+        },
+        () => {
+            element.textContent = 'Hello world';
+        }
+    );
+}
+
+export function liveRegionWrappingShadowDOM() {
+    let shadowRoot: ShadowRoot;
+
+    return createButtonCycle(
+        parent => {
+            const region = document.createElement('div');
+            region.setAttribute('aria-live', 'polite');
+            parent.appendChild(region);
+
+            const host = document.createElement('div');
+            region.appendChild(host);
+
+            shadowRoot = host.attachShadow({ mode: 'open' });
+        },
+        () => {
+            const element = document.createElement('div');
+            element.textContent = 'Hello world';
+
+            shadowRoot.appendChild(element);
+        }
+    );
+}

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "@storybook/addon-docs": "^6.4.12",
         "@storybook/html": "^6.4.12",
         "@testing-library/cypress": "^8.0.1",
-        "@testing-library/dom": "^7.31.2",
+        "@testing-library/dom": "^8.11.3",
         "@testing-library/jest-dom": "^5.14.1",
         "@types/jest": "^26.0.23",
         "@typescript-eslint/eslint-plugin": "^4.27.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2500,7 +2500,7 @@
     "@babel/runtime" "^7.14.6"
     "@testing-library/dom" "^8.1.0"
 
-"@testing-library/dom@^7.28.1", "@testing-library/dom@^7.31.2":
+"@testing-library/dom@^7.28.1":
   version "7.31.2"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.31.2.tgz#df361db38f5212b88555068ab8119f5d841a8c4a"
   integrity sha512-3UqjCpey6HiTZT92vODYLPxTBWlM8ZOOjr3LX5F37/VRipW2M1kX6I/Cm4VXzteZqfGfagg8yXywpcOgQBlNsQ==
@@ -2518,6 +2518,20 @@
   version "8.10.1"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.10.1.tgz#e24fed92ad51c619cf304c6f1410b4c76b1000c0"
   integrity sha512-rab7vpf1uGig5efWwsCOn9j4/doy+W3VBoUyzX7C4y77u0wAckwc7R8nyH6e2rw0rRzKJR+gWPiAg8zhiFbxWQ==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^5.0.0"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.9"
+    lz-string "^1.4.4"
+    pretty-format "^27.0.2"
+
+"@testing-library/dom@^8.11.3":
+  version "8.11.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.11.3.tgz#38fd63cbfe14557021e88982d931e33fb7c1a808"
+  integrity sha512-9LId28I+lx70wUiZjLvi1DB/WT2zGOxUh46glrSNMaWVx849kKAluezVzZrXJfTKKoQTmEOutLes/bHg4Bj3aA==
   dependencies:
     "@babel/code-frame" "^7.10.4"
     "@babel/runtime" "^7.12.5"


### PR DESCRIPTION
- Examples for `aria-live` usage with shadow dom
- Custom `pretty-dom` which includes contents of `ShadowRoot`. Remove once `@testing-library/dom-testing-library` adds support for it: https://github.com/testing-library/dom-testing-library/issues/413.