### PR TITLE
fix(shadow-dom): intercept `DocumentFragment` APIs

### DIFF
--- a/.storybook/stories/ShadowRoot.stories.ts
+++ b/.storybook/stories/ShadowRoot.stories.ts
@@ -115,3 +115,33 @@ export function liveRegionWrappingElementAndShadowDOM() {
         }
     );
 }
+
+export function visibilityToggle() {
+    let shadowRoot: ShadowRoot;
+
+    const element = document.createElement('div');
+    element.textContent = 'Hello world';
+
+    function appendChild() {
+        shadowRoot.appendChild(element);
+    }
+    function removeChild() {
+        shadowRoot.removeChild(element);
+    }
+
+    return createButtonCycle(
+        parent => {
+            const region = document.createElement('div');
+            region.setAttribute('aria-live', 'polite');
+            parent.appendChild(region);
+
+            const host = document.createElement('div');
+            region.appendChild(host);
+
+            shadowRoot = host.attachShadow({ mode: 'open' });
+        },
+        ...Array(50)
+            .fill([appendChild, removeChild])
+            .reduce((all, methods) => [...all, ...methods], [])
+    );
+}

--- a/src/capture-announcements.ts
+++ b/src/capture-announcements.ts
@@ -224,6 +224,10 @@ export default function CaptureAnnouncements(options: Options): Restore {
 
     // prettier-ignore
     const cleanups: Restore[] = [
+        interceptMethod(DocumentFragment.prototype, 'removeChild', onRemoveChild),
+        interceptMethod(DocumentFragment.prototype, 'append', onNodeMount),
+        interceptMethod(DocumentFragment.prototype, 'prepend', onNodeMount),
+
         interceptMethod(Element.prototype, 'setAttribute', onSetAttribute),
         interceptMethod(Element.prototype, 'removeAttribute', onRemoveAttributeBefore, 'BEFORE'),
         interceptMethod(Element.prototype, 'removeAttribute', onRemoveAttributeAfter, 'AFTER'),
@@ -234,10 +238,10 @@ export default function CaptureAnnouncements(options: Options): Restore {
         interceptMethod(Element.prototype, 'before', onNodeMount),
         interceptMethod(Element.prototype, 'append', onNodeMount),
         interceptMethod(Element.prototype, 'prepend', onNodeMount),
+
         interceptMethod(Node.prototype, 'appendChild', onNodeMount),
         interceptMethod(Node.prototype, 'insertBefore', onNodeMount),
         interceptMethod(Node.prototype, 'replaceChild', onNodeMount),
-
         interceptSetter(Node.prototype, 'textContent', onTextContentChange),
         interceptSetter(Node.prototype, 'nodeValue', onNodeValueChange)
     ];


### PR DESCRIPTION
- There are some APIs which are not inherited from `Node`, and are not included when intercepting `Element` APIs