### PR TITLE
test: fix storybook's `__test is not defined` errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,5 +84,10 @@
         "singleQuote": true,
         "tabWidth": 4,
         "printWidth": 80
+    },
+    "pnpm": {
+        "patchedDependencies": {
+            "@storybook/test-runner": "patches/@storybook__test-runner.patch"
+        }
     }
 }

--- a/patches/@storybook__test-runner.patch
+++ b/patches/@storybook__test-runner.patch
@@ -1,0 +1,52 @@
+diff --git a/dist/index.js b/dist/index.js
+index accc3632466e5b25b0122b2961e7c94a80a2759b..1984513ac34861abe5d800cbfa2dd7ddad770bef 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -13566,7 +13566,7 @@ var testPrefixer = /* @__PURE__ */ __name((context) => {
+           await globalThis.__sbPreVisit(page, context);
+         }
+ 
+-        const result = await page.evaluate(({ id, hasPlayFn }) => __test(id, hasPlayFn), {
++        const result = await page.addInitScript(({ id, hasPlayFn }) => __test(id, hasPlayFn), {
+           id: %%id%%,
+         });
+   
+diff --git a/dist/index.mjs b/dist/index.mjs
+index 3bef97836744b3c38d5cf7cbf1a7da806ea1b850..d3fc1cfdecad3eed12566bdfb8b51d4da4a339dc 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -13549,7 +13549,7 @@ var testPrefixer = /* @__PURE__ */ __name((context) => {
+           await globalThis.__sbPreVisit(page, context);
+         }
+ 
+-        const result = await page.evaluate(({ id, hasPlayFn }) => __test(id, hasPlayFn), {
++        const result = await page.addInitScript(({ id, hasPlayFn }) => __test(id, hasPlayFn), {
+           id: %%id%%,
+         });
+   
+diff --git a/dist/test-storybook.js b/dist/test-storybook.js
+index f5f2a8f08d189c87316d69aabe906d2ef320e02d..c36a2d6bfc398dc593d56feb2f4290f6f5e21aa3 100755
+--- a/dist/test-storybook.js
++++ b/dist/test-storybook.js
+@@ -17623,7 +17623,7 @@ var testPrefixer = /* @__PURE__ */ __name((context) => {
+           await globalThis.__sbPreVisit(page, context);
+         }
+ 
+-        const result = await page.evaluate(({ id, hasPlayFn }) => __test(id, hasPlayFn), {
++        const result = await page.addInitScript(({ id, hasPlayFn }) => __test(id, hasPlayFn), {
+           id: %%id%%,
+         });
+   
+diff --git a/dist/test-storybook.mjs b/dist/test-storybook.mjs
+index 2ac7d7a93f6582ea736dff80709646ede0def3fd..14f3dc1cb9b69a203604609075c82acaf1206874 100755
+--- a/dist/test-storybook.mjs
++++ b/dist/test-storybook.mjs
+@@ -17629,7 +17629,7 @@ var testPrefixer = /* @__PURE__ */ __name((context) => {
+           await globalThis.__sbPreVisit(page, context);
+         }
+ 
+-        const result = await page.evaluate(({ id, hasPlayFn }) => __test(id, hasPlayFn), {
++        const result = await page.addInitScript(({ id, hasPlayFn }) => __test(id, hasPlayFn), {
+           id: %%id%%,
+         });
+   

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@storybook/test-runner':
+    hash: bievocczwd5fugftmd3rc6rl4u
+    path: patches/@storybook__test-runner.patch
+
 importers:
 
   .:
@@ -40,7 +45,7 @@ importers:
         version: 8.2.8(storybook@8.2.8(@babel/preset-env@7.24.6(@babel/core@7.24.6)))
       '@storybook/test-runner':
         specifier: ^0.19.1
-        version: 0.19.1(@types/node@20.14.10)(prettier@3.3.3)(storybook@8.2.8(@babel/preset-env@7.24.6(@babel/core@7.24.6)))
+        version: 0.19.1(patch_hash=bievocczwd5fugftmd3rc6rl4u)(@types/node@20.14.10)(prettier@3.3.3)(storybook@8.2.8(@babel/preset-env@7.24.6(@babel/core@7.24.6)))
       '@storybook/testing-library':
         specifier: ^0.2.2
         version: 0.2.2
@@ -7050,7 +7055,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       storybook: 8.2.8(@babel/preset-env@7.24.6(@babel/core@7.24.6))
 
-  '@storybook/test-runner@0.19.1(@types/node@20.14.10)(prettier@3.3.3)(storybook@8.2.8(@babel/preset-env@7.24.6(@babel/core@7.24.6)))':
+  '@storybook/test-runner@0.19.1(patch_hash=bievocczwd5fugftmd3rc6rl4u)(@types/node@20.14.10)(prettier@3.3.3)(storybook@8.2.8(@babel/preset-env@7.24.6(@babel/core@7.24.6)))':
     dependencies:
       '@babel/core': 7.24.6
       '@babel/generator': 7.24.6


### PR DESCRIPTION
- These errors happen ~50% of the time: https://github.com/storybookjs/test-runner/issues/68
- Apply patch from https://github.com/storybookjs/test-runner/pull/445 